### PR TITLE
Fix font-size unit in CSS

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -11,7 +11,7 @@
 
 p {
     color: darkgrey;
-    font-size: 24;
+    font-size: 24px;
 }
 
 img {


### PR DESCRIPTION
## Summary
- ensure paragraph text uses a valid font-size with px units

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4fa5ed2c8328acf79447d125712e