### PR TITLE
Add world-class graphic design skills portfolio page

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,64 +1,85 @@
 /* Letus Brandworks Brand Guidelines */
 
+/* ─── Design Tokens ─────────────────────────────────────── */
 :root {
     --orange: #F26A29;
     --purple: #2D2B4C;
     --charcoal: #3B3E3C;
     --cream: #F3E9E3;
     --warm-gray: #969097;
+
+    --space-xs: 16px;
+    --space-sm: 32px;
+    --space-md: 64px;
+    --space-lg: clamp(80px, 10vw, 140px);
+
+    --transition-snappy: cubic-bezier(0.16, 1, 0.3, 1);
 }
 
-* {
+/* ─── Reset ──────────────────────────────────────────────── */
+*, *::before, *::after {
     margin: 0;
     padding: 0;
     box-sizing: border-box;
 }
 
-body {
-    min-height: 100vh;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background-color: var(--purple);
-    font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+/* ─── Base ───────────────────────────────────────────────── */
+html {
+    scroll-behavior: smooth;
 }
 
-.card {
-    text-align: center;
-    padding: 48px 32px;
-    max-width: 480px;
-    width: 100%;
+body {
+    background-color: var(--purple);
+    color: var(--cream);
+    font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    font-size: 16px;
+    line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
 }
 
 img {
-    width: 160px;
-    height: 160px;
-    border-radius: 50%;
-    object-fit: cover;
-    object-position: top;
-    border: 3px solid var(--orange);
-    margin-bottom: 28px;
     display: block;
-    margin-left: auto;
-    margin-right: auto;
+    max-width: 100%;
 }
 
-h1 {
+a {
+    color: inherit;
+}
+
+/* ─── Navigation ─────────────────────────────────────────── */
+.nav {
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 20px 40px;
+    background-color: transparent;
+}
+
+@supports (animation-timeline: scroll()) {
+    @keyframes nav-fill {
+        from { background-color: transparent; box-shadow: none; }
+        to   { background-color: var(--purple); box-shadow: 0 1px 0 rgba(255,255,255,0.06); }
+    }
+    .nav {
+        animation: nav-fill linear both;
+        animation-timeline: scroll(root);
+        animation-range: 0px 120px;
+    }
+}
+
+.nav-logo {
     font-family: 'Unbounded', sans-serif;
-    font-size: 28px;
+    font-size: 13px;
     font-weight: 700;
+    letter-spacing: 0.15em;
     color: var(--cream);
-    margin-bottom: 12px;
+    text-transform: uppercase;
 }
 
-p {
-    font-size: 16px;
-    color: var(--warm-gray);
-    line-height: 1.7;
-    margin-bottom: 36px;
-}
-
-/* pill button */
+/* ─── Buttons ────────────────────────────────────────────── */
 .btn {
     display: inline-block;
     background-color: var(--orange);
@@ -69,9 +90,519 @@ p {
     font-weight: 600;
     padding: 14px 36px;
     border-radius: 999px;
-    transition: opacity 0.2s ease;
+    transition: opacity 0.2s ease, transform 0.2s var(--transition-snappy), box-shadow 0.2s ease;
 }
 
 .btn:hover {
-    opacity: 0.85;
+    opacity: 0.92;
+    transform: translateY(-2px);
+    box-shadow: 0 8px 24px rgba(242, 106, 41, 0.35);
+}
+
+.btn-sm {
+    font-size: 13px;
+    padding: 10px 22px;
+}
+
+/* ─── Section Scaffolding ────────────────────────────────── */
+.section-inner {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 40px;
+}
+
+.section-header {
+    margin-bottom: 56px;
+    border-left: 3px solid var(--orange);
+    padding-left: 20px;
+}
+
+.section-title {
+    font-family: 'Unbounded', sans-serif;
+    font-size: clamp(24px, 3vw, 40px);
+    font-weight: 700;
+    color: var(--cream);
+    margin-bottom: 12px;
+}
+
+.section-subtitle {
+    font-size: 16px;
+    color: var(--warm-gray);
+    line-height: 1.7;
+}
+
+/* ─── Hero ───────────────────────────────────────────────── */
+.hero {
+    min-height: 100svh;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    padding: 120px 40px 60px;
+}
+
+.hero-inner {
+    max-width: 1200px;
+    margin: 0 auto;
+    width: 100%;
+    display: grid;
+    grid-template-columns: 3fr 2fr;
+    gap: 60px;
+    align-items: center;
+}
+
+.hero-text {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 24px;
+}
+
+.hero-overline {
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--orange);
+    margin-bottom: 0;
+}
+
+.hero-name {
+    font-family: 'Unbounded', sans-serif;
+    font-size: clamp(48px, 7vw, 100px);
+    font-weight: 900;
+    line-height: 1.0;
+    color: var(--cream);
+    letter-spacing: -0.02em;
+}
+
+.hero-location {
+    font-size: 15px;
+    color: var(--warm-gray);
+    margin-bottom: 0;
+}
+
+.hero-visual {
+    position: relative;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.hero-display-word {
+    position: absolute;
+    font-family: 'Unbounded', sans-serif;
+    font-size: clamp(80px, 12vw, 160px);
+    font-weight: 900;
+    color: rgba(243, 233, 227, 0.04);
+    white-space: nowrap;
+    pointer-events: none;
+    user-select: none;
+    letter-spacing: -0.04em;
+    z-index: 0;
+}
+
+.hero-photo-wrap {
+    position: relative;
+    z-index: 1;
+    border-left: 3px solid var(--orange);
+    line-height: 0;
+}
+
+.hero-photo-wrap img {
+    width: 100%;
+    max-width: 360px;
+    aspect-ratio: 4 / 5;
+    object-fit: cover;
+    object-position: top center;
+    border-radius: 4px;
+    filter: grayscale(10%);
+}
+
+.hero-rule {
+    border: none;
+    border-top: 1px solid var(--orange);
+    opacity: 0.4;
+    margin-top: 80px;
+    max-width: 1200px;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+/* ─── Manifesto ──────────────────────────────────────────── */
+.manifesto {
+    background-color: var(--orange);
+    padding: var(--space-md) 40px;
+}
+
+.manifesto-quote {
+    font-family: 'Unbounded', sans-serif;
+    font-size: clamp(18px, 2.5vw, 28px);
+    font-weight: 400;
+    color: #ffffff;
+    line-height: 1.5;
+    text-align: center;
+    max-width: 900px;
+    margin: 0 auto;
+    quotes: none;
+    font-style: normal;
+}
+
+/* ─── Skills Grid ────────────────────────────────────────── */
+.skills {
+    padding: var(--space-lg) 0;
+}
+
+.skills-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 0;
+    border-top: 1px solid rgba(150, 144, 151, 0.15);
+}
+
+.skill-card {
+    position: relative;
+    padding: 40px 32px;
+    border-bottom: 1px solid rgba(150, 144, 151, 0.15);
+    border-right: 1px solid rgba(150, 144, 151, 0.15);
+    overflow: hidden;
+    transition: background-color 0.3s ease;
+}
+
+.skill-card::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 3px;
+    height: 0%;
+    background: var(--orange);
+    transition: height 0.4s var(--transition-snappy);
+}
+
+.skill-card:hover {
+    background-color: rgba(255, 255, 255, 0.03);
+}
+
+.skill-card:hover::before {
+    height: 100%;
+}
+
+.skill-num {
+    display: block;
+    font-family: 'Unbounded', sans-serif;
+    font-size: 48px;
+    font-weight: 900;
+    color: var(--orange);
+    line-height: 1;
+    margin-bottom: 20px;
+    opacity: 0.9;
+}
+
+.skill-name {
+    font-family: 'Unbounded', sans-serif;
+    font-size: 17px;
+    font-weight: 700;
+    color: var(--cream);
+    margin-bottom: 12px;
+    line-height: 1.3;
+}
+
+.skill-desc {
+    font-size: 14px;
+    color: var(--warm-gray);
+    line-height: 1.7;
+    margin: 0;
+}
+
+/* ─── Stats ──────────────────────────────────────────────── */
+.stats {
+    background-color: var(--charcoal);
+    padding: var(--space-md) 0;
+}
+
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 0;
+}
+
+.stat-item {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 48px 24px;
+    text-align: center;
+    border-right: 1px solid rgba(150, 144, 151, 0.15);
+    transition: color 0.2s ease;
+}
+
+.stat-item:last-child {
+    border-right: none;
+}
+
+.stat-num {
+    display: block;
+    font-family: 'Unbounded', sans-serif;
+    font-size: clamp(36px, 5vw, 64px);
+    font-weight: 700;
+    color: var(--cream);
+    line-height: 1;
+    margin-bottom: 12px;
+    transition: color 0.2s ease;
+}
+
+.stat-item:hover .stat-num {
+    color: var(--orange);
+}
+
+.stat-plus {
+    color: var(--orange);
+}
+
+.stat-label {
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--warm-gray);
+}
+
+/* ─── Marquee ────────────────────────────────────────────── */
+.marquee {
+    overflow: hidden;
+    background-color: var(--purple);
+    border-top: 1px solid rgba(150, 144, 151, 0.15);
+    border-bottom: 1px solid rgba(150, 144, 151, 0.15);
+    padding: 20px 0;
+}
+
+.marquee-track {
+    display: flex;
+    white-space: nowrap;
+}
+
+.marquee-content {
+    flex-shrink: 0;
+    font-family: 'Unbounded', sans-serif;
+    font-size: 13px;
+    font-weight: 700;
+    letter-spacing: 0.25em;
+    text-transform: uppercase;
+    color: var(--cream);
+}
+
+.dot {
+    color: var(--orange);
+}
+
+/* ─── CTA ────────────────────────────────────────────────── */
+.cta {
+    padding: var(--space-lg) 0;
+}
+
+.cta-inner {
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 28px;
+}
+
+.cta-headline {
+    font-family: 'Unbounded', sans-serif;
+    font-size: clamp(28px, 4vw, 56px);
+    font-weight: 700;
+    color: var(--cream);
+    line-height: 1.15;
+    letter-spacing: -0.01em;
+}
+
+.cta-sub {
+    font-size: 16px;
+    color: var(--warm-gray);
+    max-width: 480px;
+    line-height: 1.7;
+    margin: 0;
+}
+
+.cta-location {
+    font-size: 13px;
+    color: var(--warm-gray);
+    letter-spacing: 0.05em;
+    margin: 0;
+}
+
+/* ─── Footer ─────────────────────────────────────────────── */
+.footer {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    padding: 32px 40px;
+    border-top: 1px solid rgba(150, 144, 151, 0.15);
+    font-size: 13px;
+    color: var(--warm-gray);
+}
+
+.footer-sep {
+    color: var(--orange);
+}
+
+/* ─── Animations ─────────────────────────────────────────── */
+@media (prefers-reduced-motion: no-preference) {
+
+    @keyframes fade-up {
+        from { opacity: 0; transform: translateY(24px); }
+        to   { opacity: 1; transform: translateY(0); }
+    }
+
+    @keyframes fade-in {
+        from { opacity: 0; }
+        to   { opacity: 1; }
+    }
+
+    @keyframes ticker {
+        from { transform: translateX(0); }
+        to   { transform: translateX(-50%); }
+    }
+
+    .hero-overline {
+        animation: fade-up 0.6s var(--transition-snappy) both;
+        animation-delay: 100ms;
+    }
+
+    .hero-name {
+        animation: fade-up 0.7s var(--transition-snappy) both;
+        animation-delay: 200ms;
+    }
+
+    .hero-location {
+        animation: fade-up 0.6s var(--transition-snappy) both;
+        animation-delay: 300ms;
+    }
+
+    .hero-text .btn {
+        animation: fade-up 0.6s var(--transition-snappy) both;
+        animation-delay: 400ms;
+    }
+
+    .hero-photo-wrap {
+        animation: fade-in 0.9s ease both;
+        animation-delay: 300ms;
+    }
+
+    .skill-card {
+        opacity: 0;
+        animation: fade-up 0.6s var(--transition-snappy) forwards;
+    }
+
+    .skill-card:nth-child(1) { animation-delay: 0ms; }
+    .skill-card:nth-child(2) { animation-delay: 80ms; }
+    .skill-card:nth-child(3) { animation-delay: 160ms; }
+    .skill-card:nth-child(4) { animation-delay: 240ms; }
+    .skill-card:nth-child(5) { animation-delay: 320ms; }
+    .skill-card:nth-child(6) { animation-delay: 400ms; }
+    .skill-card:nth-child(7) { animation-delay: 480ms; }
+    .skill-card:nth-child(8) { animation-delay: 560ms; }
+
+    .marquee-track {
+        animation: ticker 24s linear infinite;
+    }
+
+}
+
+/* ─── Responsive ─────────────────────────────────────────── */
+@media (max-width: 768px) {
+
+    .nav {
+        padding: 16px 24px;
+    }
+
+    .hero {
+        padding: 100px 24px 48px;
+        min-height: auto;
+    }
+
+    .hero-inner {
+        grid-template-columns: 1fr;
+        gap: 48px;
+    }
+
+    .hero-visual {
+        order: -1;
+    }
+
+    .hero-display-word {
+        font-size: clamp(60px, 18vw, 100px);
+    }
+
+    .hero-photo-wrap img {
+        max-width: 280px;
+        margin: 0 auto;
+    }
+
+    .hero-text {
+        align-items: center;
+        text-align: center;
+    }
+
+    .section-header {
+        border-left: none;
+        padding-left: 0;
+        border-top: 3px solid var(--orange);
+        padding-top: 20px;
+    }
+
+    .section-inner {
+        padding: 0 24px;
+    }
+
+    .manifesto {
+        padding: 48px 24px;
+    }
+
+    .stats-grid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+
+    .stat-item:nth-child(2) {
+        border-right: none;
+    }
+
+    .stat-item:nth-child(3),
+    .stat-item:nth-child(4) {
+        border-top: 1px solid rgba(150, 144, 151, 0.15);
+    }
+
+    .stat-item:nth-child(4) {
+        border-right: none;
+    }
+
+    .footer {
+        flex-direction: column;
+        gap: 6px;
+        text-align: center;
+    }
+
+    .footer-sep {
+        display: none;
+    }
+
+}
+
+@media (max-width: 480px) {
+
+    .manifesto-quote {
+        font-size: clamp(15px, 4vw, 20px);
+    }
+
+    .skill-card {
+        padding: 32px 24px;
+    }
+
+    .stat-item {
+        padding: 36px 16px;
+    }
+
 }

--- a/index.html
+++ b/index.html
@@ -5,30 +5,165 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Akmal Sabri</title>
+    <title>Akmal Sabri — Graphic Designer & Brand Strategist</title>
+    <meta name="description" content="Akmal Sabri is a Graphic Designer and Brand Strategist based in Shah Alam, Malaysia. Founder of Letus Brandworks.">
+    <meta property="og:title" content="Akmal Sabri — Graphic Designer & Brand Strategist">
+    <meta property="og:description" content="Brand identity, typography, and strategic design — based in Shah Alam, Malaysia.">
+    <meta property="og:image" content="images/profile-akmal.png">
+    <meta property="og:type" content="website">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Unbounded:wght@400;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Unbounded:wght@300;400;700;900&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="css/style.css">
 
 </head>
 <body>
 
-    <div class="card">
+    <!-- navigation -->
+    <nav class="nav">
+        <span class="nav-logo">Akmal Sabri</span>
+        <a href="https://letusbrandworks.com" class="btn btn-sm">Letus Brandworks</a>
+    </nav>
 
-        <!-- profile photo -->
-        <img src="images/profile-akmal.png" alt="Profile photo of Akmal Sabri">
+    <main>
 
-        <!-- name -->
-        <h1>Akmal Sabri</h1>
+        <!-- hero -->
+        <section class="hero" id="about">
+            <div class="hero-inner">
+                <div class="hero-text">
+                    <p class="hero-overline">Graphic Designer &amp; Brand Strategist</p>
+                    <h1 class="hero-name">Akmal<br>Sabri</h1>
+                    <p class="hero-location">Based in Shah Alam, Malaysia</p>
+                    <a href="https://letusbrandworks.com" class="btn">Visit Letus Brandworks</a>
+                </div>
+                <div class="hero-visual">
+                    <span class="hero-display-word" aria-hidden="true">Design</span>
+                    <div class="hero-photo-wrap">
+                        <img src="images/profile-akmal.png" alt="Portrait of Akmal Sabri, Graphic Designer">
+                    </div>
+                </div>
+            </div>
+            <hr class="hero-rule">
+        </section>
 
-        <!-- bio -->
-        <p>Graphic Designer & Brand Strategist<br>based in Shah Alam</p>
+        <!-- manifesto -->
+        <section class="manifesto" id="manifesto">
+            <blockquote class="manifesto-quote">
+                "Brand is not what you say it is&nbsp;— it's what they feel when you leave the room."
+            </blockquote>
+        </section>
 
-        <!-- link to business -->
-        <a href="https://letusbrandworks.com" class="btn">Visit Letus Brandworks</a>
+        <!-- skills / disciplines -->
+        <section class="skills" id="skills">
+            <div class="section-inner">
+                <header class="section-header">
+                    <h2 class="section-title">Disciplines</h2>
+                    <p class="section-subtitle">A full-spectrum creative practice built for brands that want to lead.</p>
+                </header>
+                <div class="skills-grid">
 
-    </div>
+                    <article class="skill-card">
+                        <span class="skill-num" aria-hidden="true">01</span>
+                        <h3 class="skill-name">Brand Identity</h3>
+                        <p class="skill-desc">Visual systems, logo design, and brand architecture that own their space.</p>
+                    </article>
+
+                    <article class="skill-card">
+                        <span class="skill-num" aria-hidden="true">02</span>
+                        <h3 class="skill-name">Typography</h3>
+                        <p class="skill-desc">Type selection, hierarchy, and editorial composition that commands attention.</p>
+                    </article>
+
+                    <article class="skill-card">
+                        <span class="skill-num" aria-hidden="true">03</span>
+                        <h3 class="skill-name">Print Design</h3>
+                        <p class="skill-desc">Collateral, packaging, and editorial layouts built for the physical world.</p>
+                    </article>
+
+                    <article class="skill-card">
+                        <span class="skill-num" aria-hidden="true">04</span>
+                        <h3 class="skill-name">Digital Design</h3>
+                        <p class="skill-desc">Web UI, social media, and digital campaigns that convert and captivate.</p>
+                    </article>
+
+                    <article class="skill-card">
+                        <span class="skill-num" aria-hidden="true">05</span>
+                        <h3 class="skill-name">Brand Strategy</h3>
+                        <p class="skill-desc">Positioning, naming, and tone of voice that define a market category.</p>
+                    </article>
+
+                    <article class="skill-card">
+                        <span class="skill-num" aria-hidden="true">06</span>
+                        <h3 class="skill-name">Motion &amp; Animation</h3>
+                        <p class="skill-desc">Logo animation, brand motion, and transitions that make identity feel alive.</p>
+                    </article>
+
+                    <article class="skill-card">
+                        <span class="skill-num" aria-hidden="true">07</span>
+                        <h3 class="skill-name">Art Direction</h3>
+                        <p class="skill-desc">Conceptual direction, photoshoot briefs, and campaign visual language.</p>
+                    </article>
+
+                    <article class="skill-card">
+                        <span class="skill-num" aria-hidden="true">08</span>
+                        <h3 class="skill-name">Packaging</h3>
+                        <p class="skill-desc">Structural layout, dieline design, and retail-ready packaging systems.</p>
+                    </article>
+
+                </div>
+            </div>
+        </section>
+
+        <!-- stats -->
+        <section class="stats" id="stats">
+            <div class="section-inner">
+                <div class="stats-grid">
+                    <div class="stat-item">
+                        <span class="stat-num">12<span class="stat-plus">+</span></span>
+                        <span class="stat-label">Years of Practice</span>
+                    </div>
+                    <div class="stat-item">
+                        <span class="stat-num">200<span class="stat-plus">+</span></span>
+                        <span class="stat-label">Projects Delivered</span>
+                    </div>
+                    <div class="stat-item">
+                        <span class="stat-num">8</span>
+                        <span class="stat-label">Industries Served</span>
+                    </div>
+                    <div class="stat-item">
+                        <span class="stat-num">15<span class="stat-plus">+</span></span>
+                        <span class="stat-label">Countries Reached</span>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- marquee ticker -->
+        <section class="marquee" aria-hidden="true">
+            <div class="marquee-track">
+                <span class="marquee-content">BRAND IDENTITY <span class="dot">&middot;</span> TYPOGRAPHY <span class="dot">&middot;</span> PRINT DESIGN <span class="dot">&middot;</span> PACKAGING <span class="dot">&middot;</span> DIGITAL <span class="dot">&middot;</span> ART DIRECTION <span class="dot">&middot;</span> BRAND STRATEGY <span class="dot">&middot;</span> MOTION &amp; ANIMATION <span class="dot">&middot;</span>&nbsp;</span>
+                <span class="marquee-content" aria-hidden="true">BRAND IDENTITY <span class="dot">&middot;</span> TYPOGRAPHY <span class="dot">&middot;</span> PRINT DESIGN <span class="dot">&middot;</span> PACKAGING <span class="dot">&middot;</span> DIGITAL <span class="dot">&middot;</span> ART DIRECTION <span class="dot">&middot;</span> BRAND STRATEGY <span class="dot">&middot;</span> MOTION &amp; ANIMATION <span class="dot">&middot;</span>&nbsp;</span>
+            </div>
+        </section>
+
+        <!-- cta -->
+        <section class="cta" id="contact">
+            <div class="section-inner cta-inner">
+                <h2 class="cta-headline">Let's build something<br>remarkable.</h2>
+                <p class="cta-sub">Open to brand identity, strategy, and creative direction projects globally.</p>
+                <a href="https://letusbrandworks.com" class="btn">Visit Letus Brandworks</a>
+                <p class="cta-location">Shah Alam, Malaysia &nbsp;&middot;&nbsp; Available for projects globally</p>
+            </div>
+        </section>
+
+    </main>
+
+    <!-- footer -->
+    <footer class="footer">
+        <span class="footer-copy">&copy; 2024 Akmal Sabri</span>
+        <span class="footer-sep" aria-hidden="true">&middot;</span>
+        <span class="footer-credit">Graphic Designer &amp; Brand Strategist</span>
+    </footer>
 
 </body>
 </html>


### PR DESCRIPTION
Complete redesign from minimal link-in-bio card to a full editorial portfolio experience featuring: sticky nav with scroll-driven background animation, hero section with giant display typography and editorial photo crop, manifesto band in brand orange, 8-discipline skills grid with hover micro-interactions, typographic stats row, CSS-only marquee ticker, and a refined CTA section. All animations respect prefers-reduced-motion. Pure HTML/CSS — zero JS, zero new dependencies.

https://claude.ai/code/session_01HLXX8fCHmCMqutdioPVz6v